### PR TITLE
Added afterLoad callback.

### DIFF
--- a/jquery.nivo.slider.js
+++ b/jquery.nivo.slider.js
@@ -242,6 +242,9 @@
 				//Trigger the afterChange callback
 				settings.afterChange.call(this);
 			});
+			
+			//Trigger the afterLoad callback
+			settings.afterLoad.call(this);
 		});
 		
 		function nivoRun(slider, kids, settings, nudge){
@@ -451,6 +454,7 @@
 		pauseOnHover:true,
 		manualAdvance:false,
 		captionOpacity:0.8,
+		afterLoad: function(){},
 		beforeChange: function(){},
 		afterChange: function(){},
 		slideshowEnd: function(){}


### PR DESCRIPTION
I added an afterLoad callback to the main jquery.nivo.slider.js file. I am using Nivo along with Colorbox and needed a way to call .colorbox() on a caption element once it has been displayed. Since Nivo "recreates" the element, I couldn't call .colorbox() on page load. I only tested it with my own site and it worked. Please consider adding a function like this in the future as it is quite helpful.
