### PR TITLE
prevent attempt to use page url (#) as an img src

### DIFF
--- a/jquery.nivo.slider.js
+++ b/jquery.nivo.slider.js
@@ -74,7 +74,7 @@
         }
         
         // Set first background
-        var sliderImg = $('<img class="nivo-main-image" src="#" />');
+        var sliderImg = $('<img/>').addClass('nivo-main-image');
         sliderImg.attr('src', vars.currentImage.attr('src')).show();
         slider.append(sliderImg);
 


### PR DESCRIPTION
Whisking an image element into existence using the old
implementation causes the browser to attempt to use the current
page as an image source ... failing in the process :-)
