### PR TITLE
Fixed slideInRight effect

### DIFF
--- a/jquery.nivo.slider.js
+++ b/jquery.nivo.slider.js
@@ -483,8 +483,10 @@
                 
                 firstSlice = $('.nivo-slice:first', slider);
                 firstSlice.css({
-                    'width': '0px',
-                    'opacity': '1'
+                    'width': slider.width()*2,
+                    'opacity': '1',
+                    'left': '',
+                    'right': '0px'
                 });
 
                 firstSlice.animate({ width: slider.width() + 'px' }, (settings.animSpeed*2), '', function(){ slider.trigger('nivo:animFinished'); });


### PR DESCRIPTION
Fix the slideInRight effect to be a mirror of the slideInLeft. The slideInLeft effect actually moves the new image into place, while the slideInRight only revealed the new image with a kind of wipe mask. Now the image slides in like it should.
