### PR TITLE
Filtering out <script> children to play nicely with emberjs.

### DIFF
--- a/jquery.nivo.slider.js
+++ b/jquery.nivo.slider.js
@@ -28,7 +28,9 @@
         slider.data('nivo:vars', vars).addClass('nivoSlider');
 
         // Find our slider children
-        var kids = slider.children();
+        var kids = slider.children().filter(function(kid){
+            return !$(kid).is('script');
+        });
         kids.each(function() {
             var child = $(this);
             var link = '';


### PR DESCRIPTION
Using Nivo-Slider as an Emberjs Component results in <script> elements created by Emberjs showing in the slideshow as empty slides. This fix filter them out, solving the issue.
