### PR TITLE
Add Element Selector Option

### DIFF
--- a/jquery.nivo.slider.js
+++ b/jquery.nivo.slider.js
@@ -28,7 +28,7 @@
         slider.data('nivo:vars', vars).addClass('nivoSlider');
 
         // Find our slider children
-        var kids = slider.children();
+        var kids = slider.children(settings.slideSelector);
         kids.each(function() {
             var child = $(this);
             var link = '';
@@ -650,6 +650,7 @@
         prevText: 'Prev',
         nextText: 'Next',
         randomStart: false,
+        slideSelector: '',
         beforeChange: function(){},
         afterChange: function(){},
         slideshowEnd: function(){},


### PR DESCRIPTION
This commit allows you to provider a selector to select which elements you want to be a part of the slider.

`$("#gallery").nivoSlider({ slideSelector: "img" });`

My use case was with using Ember and having to deal with `<script>` tags that are generated within the slider container.

``` html
<div id="gallery">
    <script id="metamorph-0-start"></script>
    <script id="metamorph-1-start"></script>
    <img src="someImage" />
    <img src="someImage2" />
    <script id="metamorph-1-end"></script>
    <script id="metamorph-0-end"></script>
</div>
```
